### PR TITLE
Folder UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+/node_modules/*
+!/node_modules/quill
+/node_modules/quill/*
+!node_modules/quill/dist
+/node_modules/quill/dist/*
+/node_modules/quill/dist/quill.bubble.css
+/node_modules/quill/dist/quill.core.css
+/node_modules/quill/dist/quill.core.js
+/node_modules/quill/dist/quill.min.js
+/node_modules/quill/dist/quill.min.js.map
+/node_modules/quill/dist/quill.snow.css
+!/node_modules/quill/dist/quill.js
+
+
 /.pnp
 .pnp.js
 

--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,10 @@ import MainApp from "./components/MainApp";
 // import AddMemo from "./components/AddMemo";
 // import Editor from "./components/Editor";
 // import { useState } from "react";
-//"hi"
+
 import "antd/dist/antd.css";
 const App = () => {
-
+  console.log("hello")
   return (
     <div className="App">
       <MainApp />

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import MainApp from "./components/MainApp";
 // import AddMemo from "./components/AddMemo";
 // import Editor from "./components/Editor";
 // import { useState } from "react";
+//"hi"
 import "antd/dist/antd.css";
 const App = () => {
 

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import MainApp from "./components/MainApp";
 
 import "antd/dist/antd.css";
 const App = () => {
-  console.log("hello")
+  
   return (
     <div className="App">
       <MainApp />

--- a/src/components/BreadCrumb/BreadCrumbContainer.js
+++ b/src/components/BreadCrumb/BreadCrumbContainer.js
@@ -1,0 +1,14 @@
+import BreadCrumbPresenter from "./BreadCrumbPresenter"
+import React from "react"
+import {get_root_pointer} from "../../memo-storage/fs-pointer"
+const BreadCrumbContainer = (cwd, onChangeDir) => {
+    const root_pointer =get_root_pointer() ;
+    
+    return(
+        <BreadCrumbPresenter
+            cwd ={cwd}>
+        </BreadCrumbPresenter>
+    );
+};
+
+export default BreadCrumbContainer;

--- a/src/components/BreadCrumb/BreadCrumbPresenter.js
+++ b/src/components/BreadCrumb/BreadCrumbPresenter.js
@@ -1,0 +1,33 @@
+import React, {useState} from "react"
+import {Breadcrumb} from "antd"
+
+
+const BreadCrumbPresenter = (cwd) => {
+    //console.log(cwd.cwd.cwd)
+    let hierarchy =[];
+    const real_cwd = cwd.cwd.cwd
+    let parent = real_cwd.parent()
+    //console.log(parent)
+    console.log(real_cwd)
+    //hierarchy.push("root")
+    const adding_hierarchy = (real_cwd) => {
+        if(real_cwd.name !='/'){
+            hierarchy.unshift(real_cwd.name)
+            return adding_hierarchy(real_cwd.parent())
+        }
+        else{
+            hierarchy.unshift("root")
+            return
+        }
+    }
+    adding_hierarchy(real_cwd)
+    
+    //console.log(hierarchy)
+    const hierarchy_render = hierarchy.map((pt) => 
+    (<Breadcrumb.Item>{pt}</Breadcrumb.Item>))
+    return (
+        hierarchy_render
+    )
+}
+
+export default BreadCrumbPresenter;

--- a/src/components/BreadCrumb/BreadCrumbPresenter.js
+++ b/src/components/BreadCrumb/BreadCrumbPresenter.js
@@ -1,14 +1,15 @@
 import React, {useState} from "react"
 import {Breadcrumb} from "antd"
+import BreadcrumbItem from "antd/lib/breadcrumb/BreadcrumbItem";
 
 
 const BreadCrumbPresenter = (cwd) => {
     //console.log(cwd.cwd.cwd)
     let hierarchy =[];
+    let folder_title = ""
     const real_cwd = cwd.cwd.cwd
-    let parent = real_cwd.parent()
     //console.log(parent)
-    console.log(real_cwd)
+    //console.log(real_cwd)
     //hierarchy.push("root")
     const adding_hierarchy = (real_cwd) => {
         if(real_cwd.name !='/'){
@@ -22,12 +23,51 @@ const BreadCrumbPresenter = (cwd) => {
     }
     adding_hierarchy(real_cwd)
     
+    if (real_cwd.name ==='/'){
+        folder_title = "home"
+    }
+    else{
+        folder_title = real_cwd.name
+    }
     //console.log(hierarchy)
     const hierarchy_render = hierarchy.map((pt) => 
     (<Breadcrumb.Item>{pt}</Breadcrumb.Item>))
     return (
-        hierarchy_render
+        <div style = {BreadcrumbBox_style}>
+            <Breadcrumb style = {Breadcrumb_style}>
+                {hierarchy_render}
+            </Breadcrumb>
+            <div style = {{padding: "14px 0px 6px", fontSize:18}}>{folder_title}</div>
+        </div>
     )
+}
+
+
+const BreadcrumbBox_style = {
+
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    padding: "16px 24px",
+    margin: "auto",
+    position: "relative",
+    width: "80%",
+    height: "102px",
+    
+    top:"30px",
+    bottom:"30px",
+    backgroundColor: "#FAFAFA",
+    borderRadius: "10px" 
+}
+const Breadcrumb_style = {
+
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    padding:"0px",
+    fontFamily:"Roboto",
+    fontStyle:"normal",
+    fontWeight:"normal"
 }
 
 export default BreadCrumbPresenter;

--- a/src/components/BreadCrumb/BreadCrumbPresenter.js
+++ b/src/components/BreadCrumb/BreadCrumbPresenter.js
@@ -37,7 +37,7 @@ const BreadCrumbPresenter = (cwd) => {
             <Breadcrumb style = {Breadcrumb_style}>
                 {hierarchy_render}
             </Breadcrumb>
-            <div style = {{padding: "14px 0px 6px", fontSize:18}}>{folder_title}</div>
+            <strong style = {{padding: "14px 0px 6px", fontSize:18}}>{folder_title}</strong>
         </div>
     )
 }

--- a/src/components/BreadCrumb/index.js
+++ b/src/components/BreadCrumb/index.js
@@ -1,0 +1,3 @@
+import BreadCrumbContainer from "./BreadCrumbContainer";
+
+export default BreadCrumbContainer

--- a/src/components/List/ListPresenter.js
+++ b/src/components/List/ListPresenter.js
@@ -15,7 +15,11 @@ const ListPresenter = ({
   cwd,
 }) => {
   return (
-    <div>
+    <div style ={overallListStyle}>
+      <div style = {titleBoxStyle}>
+        <div>Title</div> 
+        <div>Last Edited Time</div>
+      </div>
       <List
         dataSource={[".."]}
         style={listWrapperStyle}
@@ -57,9 +61,32 @@ const ListPresenter = ({
 };
 
 const listWrapperStyle = {
-  width: "90%",
-  marginLeft: "auto",
-  marginRight: "auto",
+  justifyContent: "flex-start",
+  alignItems: "flex-start",
+  margin: "auto",
+  width: "95%"
 };
+const overallListStyle = {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  
+  width: "80%",
+  
+  
+  margin: "auto",
+  
+}
+const titleBoxStyle = {
+  display: "flex",
+  justifyContent:"space-between",
+  padding: "15px 24px",
+  margin: "50px 0px 0px 0px",
+  position: "relative",
+  width: "100%",
+  height: "50px",
+  backgroundColor: "#FAFAFA",
+    
+}
 
 export default ListPresenter;

--- a/src/components/List/ListPresenter.js
+++ b/src/components/List/ListPresenter.js
@@ -42,8 +42,9 @@ const ListPresenter = ({
         dataSource={memoOrderedList()}
         style={listWrapperStyle}
         renderItem={(item) => (
-          <List.Item>
+          <List.Item style ={{width:"100%"}}>
             <ListItem
+              style ={{height:"100px"}}
               title={item.title}
               content={item.content}
               uid={item.uid}

--- a/src/components/ListDirItem/ListDirItemPresenter.js
+++ b/src/components/ListDirItem/ListDirItemPresenter.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { FolderOutlined } from "@ant-design/icons";
+import { FolderFilled } from "@ant-design/icons";
 
 const ListDirItemPresenter = ({ name }) => {
   return (
     <div>
       <div style={listItemStyle}>
-        <FolderOutlined />
+        <FolderFilled/>
         <strong>{name}</strong>
       </div>
     </div>
@@ -16,6 +16,7 @@ const listItemStyle = {
   height: "63px",
   fontSize: "large",
   cursor: "pointer",
+  width:"100%"
 };
 const timeStyle = {
   height: "63px",

--- a/src/components/MainApp/HeaderPresenter.js
+++ b/src/components/MainApp/HeaderPresenter.js
@@ -12,6 +12,7 @@ import List from "../List";
 import PostIt from "../PostIt";
 import AddMemo from "../AddMemo";
 import Editor from "../Editor";
+import BreadCrumb from "../BreadCrumb";
 import {
   deleteMemo,
   nameAscendingSort,
@@ -263,6 +264,10 @@ const HeaderPresenter = () => {
       <div onClick={() => setId(-1)}>
         <AddMemo setter={setShowEditorTrue} />
       </div>
+      <BreadCrumb
+        cwd ={cwd}
+        onChangeDir ={onChangeDir}>
+      </BreadCrumb>
       {display === DISP.LIST && (
         <List
           showCheckbox={showCheckbox}


### PR DESCRIPTION
1. git_ignore 파일을 수정해서 node_module/quill/dist/quill.js를 git이 추적할 수 있게 만들었습니다. 새로운 quill.js 파일이 적용되면 localhost 문제가 해결됩니다. 혹시라도 적용이 안되시면 말씀해주세요.

2. Breadcrumb과 해당 folder의 타이틀을 추가했습니다.

3. 폴더 icon 변화, 메모 리스트 위의 bar를 추가했습니다.

4. post-it layout에서는 breadcrumb과 post-it의 위치가 맞지 않습니다. 회의에서 말씀드린 것처럼 최대한 기존 코드를 보존하되, 불가능하다면 다른 component를 사용해서 고쳐보겠습니다.